### PR TITLE
Update version of iptools to 52

### DIFF
--- a/admin.iptools.user.js
+++ b/admin.iptools.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Vola Admin/IP Tools
-// @version      51
+// @version      52
 // @description  Does a bunch of stuff for mods.
 // @namespace    https://volafile.org
 // @icon         https://volafile.org/favicon.ico


### PR DESCRIPTION
The script version on master is still 51, I forgot to update it with my #3 PR. This prevents other mods from getting the script auto-update.