### PR TITLE
Add Vola Tab Report Binder script

### DIFF
--- a/admin.reportsbinder.user.js
+++ b/admin.reportsbinder.user.js
@@ -6,7 +6,7 @@
 // @author       Hefty Chungus
 // @match        https://volafile.org/r/*
 // @require      https://greasemonkey.github.io/gm4-polyfill/gm4-polyfill.js
-// @require      https://raw.githubusercontent.com/volafiled/volascripts/master/dry.js
+// @require      https://cdn.jsdelivr.net/gh/volafiled/volascripts/dry.js
 // @grant        none
 // @run-at       document-start
 // ==/UserScript==
@@ -14,31 +14,23 @@
 dry.once("dom", () => {
   'use strict';
   console.log("running", GM.info.script.name, GM.info.script.version, dry.version);
-  const ke = new KeyboardEvent("keydown", {
-    key: "Enter", keyCode: "13"
-  });
-  const bindtab = "bindmehere";
-  const ci = document.getElementById("chat_input");
+  const bindtab = GM.info.script.name;
+  const tabbind = localStorage.getItem(bindtab);
   new class extends dry.Commands {
     bindreports() {
-      localStorage.setItem(bindtab, window.location.href);
+      localStorage.setItem(bindtab, config.room_id);
       dry.appendMessage("Binder", "Reports are bound to this tab now");
-      ci.value = "/reports";
-      ci.dispatchEvent(ke);
+      dry.exts.connection.call("command", dry.exts.user.info.nick, "reports", "")
     }
   }();
   new class extends dry.MessageFilter {
     showMessage(orig, nick, message, options) {
-      let tabbind = localStorage.getItem(bindtab);
-      if ("Log" === nick && tabbind === window.location.href) {
-        if (message[0].hasOwnProperty("value")) {
-          let match = message[0].value.match(`${dry.exts.user.info.nick} joined`);
-          if (!!match && !!dry.exts.user.info.staff) {
-            ci.value = "/reports";
-            ci.dispatchEvent(ke);
-          }
+      if (("Log" === nick || "Network" === nick) && tabbind === config.room_id) {
+        if (!!dry.exts.user.info.admin) {
+          dry.exts.connection.call("command", dry.exts.user.info.nick, "reports", "")
         }
       }
+      return;
     }
   }();
 });

--- a/admin.reportsbinder.user.js
+++ b/admin.reportsbinder.user.js
@@ -25,10 +25,8 @@ dry.once("dom", () => {
   }();
   new class extends dry.MessageFilter {
     showMessage(orig, nick, message, options) {
-      if (("Log" === nick || "Network" === nick) && tabbind === config.room_id) {
-        if (!!dry.exts.user.info.admin) {
-          dry.exts.connection.call("command", dry.exts.user.info.nick, "reports", "")
-        }
+      if ("Log" === nick && tabbind === config.room_id && !options.report) {
+        dry.exts.connection.call("command", dry.exts.user.info.nick, "reports", "")
       }
       return;
     }

--- a/admin.reportsbinder.user.js
+++ b/admin.reportsbinder.user.js
@@ -10,7 +10,7 @@
 // @grant        none
 // @run-at       document-start
 // ==/UserScript==
-/* globals dry */
+/* globals dry GM config */
 dry.once("dom", () => {
   'use strict';
   console.log("running", GM.info.script.name, GM.info.script.version, dry.version);
@@ -20,15 +20,14 @@ dry.once("dom", () => {
     bindreports() {
       localStorage.setItem(bindtab, config.room_id);
       dry.appendMessage("Binder", "Reports are bound to this tab now");
-      dry.exts.connection.call("command", dry.exts.user.info.nick, "reports", "")
+      dry.exts.connection.call("command", dry.exts.user.info.nick, "reports", "");
     }
   }();
   new class extends dry.MessageFilter {
     showMessage(orig, nick, message, options) {
-      if ("Log" === nick && tabbind === config.room_id && !options.report) {
-        dry.exts.connection.call("command", dry.exts.user.info.nick, "reports", "")
+      if (tabbind === config.room_id && !options.report && nick === "Log") {
+        dry.exts.connection.call("command", dry.exts.user.info.nick, "reports", "");
       }
-      return;
     }
   }();
 });

--- a/admin.reportsbinder.user.js
+++ b/admin.reportsbinder.user.js
@@ -15,7 +15,9 @@ dry.once("dom", () => {
   'use strict';
   console.log("running", GM.info.script.name, GM.info.script.version, dry.version);
   const bindtab = GM.info.script.name;
-  const tabbind = localStorage.getItem(bindtab);
+  const tabbind = function () {
+   return localStorage.getItem(bindtab);
+  };
   new class extends dry.Commands {
     bindreports() {
       localStorage.setItem(bindtab, config.room_id);
@@ -25,7 +27,7 @@ dry.once("dom", () => {
   }();
   new class extends dry.MessageFilter {
     showMessage(orig, nick, message, options) {
-      if (tabbind === config.room_id && !options.report && nick === "Log") {
+      if (nick === "Log" && tabbind() === config.room_id && !options.report) {
         dry.exts.connection.call("command", dry.exts.user.info.nick, "reports", "");
       }
     }

--- a/volatabreportbinder.user.js
+++ b/volatabreportbinder.user.js
@@ -1,0 +1,44 @@
+// ==UserScript==
+// @name         Vola Tab Report Binder
+// @version      1
+// @namespace    https://volafile.org
+// @icon         https://volafile.org/favicon.ico
+// @author       Hefty Chungus
+// @match        https://volafile.org/r/*
+// @require      https://greasemonkey.github.io/gm4-polyfill/gm4-polyfill.js
+// @require      https://raw.githubusercontent.com/volafiled/volascripts/master/dry.js
+// @grant        none
+// @run-at       document-start
+// ==/UserScript==
+/* globals dry */
+dry.once("dom", () => {
+  'use strict';
+  console.log("running", GM.info.script.name, GM.info.script.version, dry.version);
+  const ke = new KeyboardEvent("keydown", {
+    key: "Enter", keyCode: "13"
+  });
+  const bindtab = "bindmehere";
+  const ci = document.getElementById("chat_input");
+  new class extends dry.Commands {
+    bindreports() {
+      localStorage.setItem(bindtab, window.location.href);
+      dry.appendMessage("Binder", "Reports are bound to this tab now");
+      ci.value = "/reports";
+      ci.dispatchEvent(ke);
+    }
+  }();
+  new class extends dry.MessageFilter {
+    showMessage(orig, nick, message, options) {
+      let tabbind = localStorage.getItem(bindtab);
+      if ("Log" === nick && tabbind === window.location.href) {
+        if (message[0].hasOwnProperty("value")) {
+          let match = message[0].value.match(`${dry.exts.user.info.nick} joined`);
+          if (!!match && !!dry.exts.user.info.staff) {
+            ci.value = "/reports";
+            ci.dispatchEvent(ke);
+          }
+        }
+      }
+    }
+  }();
+});


### PR DESCRIPTION
When you have report tab bound to a given room and lain decides to
nuke your connection, the report tab will be bound to a random room
you have currently open, that regains connection first. This script
will bind the report room to one of your choosing by typing `/bindreports`
command in chat. The report room will be set even after browser restart.